### PR TITLE
Sf reactivate/details/edit

### DIFF
--- a/PuzzlePost/Controllers/PuzzleController.cs
+++ b/PuzzlePost/Controllers/PuzzleController.cs
@@ -161,6 +161,8 @@ namespace PuzzlePost.Controllers
             Request request = _requestRepository.GetRequestByPuzzleId(puzzle.Id);
             //current owner id should change from sender of puzzle to requester of puzzle
             puzzle.CurrentOwnerId = request.RequestingPuzzleUserId;
+            //need to also update create date time to current date when ownership switches
+            puzzle.CreateDateTime = DateTime.Now;
             //update puzzle and after updating this puzzle, it should have new currentOwnerId
             _puzzleRepository.UpdatePuzzleOwner(puzzle);
            

--- a/PuzzlePost/Controllers/PuzzleController.cs
+++ b/PuzzlePost/Controllers/PuzzleController.cs
@@ -147,26 +147,37 @@ namespace PuzzlePost.Controllers
             //    return Unauthorized();
             //}
 
+            //HISTORY UPDATE
             //get a history object via both userId (currently owner) and puzzle id where end date time is null
             History history = _historyRepository.GetHistoryByIds(userId, puzzle.Id);
             //give end date the current time
             history.EndDateOwnership = DateTime.Now;
             //then call method to update the history object to have end date of current time
             _historyRepository.UpdateHistory(history);
+
+            //REQUEST UPDATE AND PUZZLE UPDATE
+            //need to also change status of the request from pending to approved; get the request
+            //by puzzleId where status is pending (there will only be 1..)
+            Request request = _requestRepository.GetRequestByPuzzleId(puzzle.Id);
+            //current owner id should change from sender of puzzle to requester of puzzle
+            puzzle.CurrentOwnerId = request.RequestingPuzzleUserId;
             //update puzzle and after updating this puzzle, it should have new currentOwnerId
             _puzzleRepository.UpdatePuzzleOwner(puzzle);
+           
+            //update status to status id of 2 = approved
+            _requestRepository.UpdateRequestStatus(request);
+            
+            
+            //HISTORY POST
             //instanstiate a new history object
             History newHistory = new History();  
             newHistory.PuzzleId = puzzle.Id;
+            //new current owner now
             newHistory.UserProfileId = puzzle.CurrentOwnerId;
             newHistory.StartDateOwnership = DateTime.Now;
             //add new history object that now contains the information for the new owner
             _historyRepository.Add(newHistory);
-            //need to also change status of the request from pending to approved; get the request
-            //by puzzleId where status is pending (there will only be 1..)
-            Request request = _requestRepository.GetRequestByPuzzleId(puzzle.Id);
-            //update status to status id of 2 = approved
-            _requestRepository.UpdateRequestStatus(request);
+          
             return NoContent();
         }
 

--- a/PuzzlePost/Controllers/PuzzleController.cs
+++ b/PuzzlePost/Controllers/PuzzleController.cs
@@ -54,6 +54,17 @@ namespace PuzzlePost.Controllers
             return Ok(puzzle);
         }
 
+        [HttpGet("getwithuserprofile/{id}")]
+        public IActionResult GetWithUserProfile(int id)
+        {
+            Puzzle puzzle = _puzzleRepository.GetPuzzleWithUserProfileById(id);
+            if (puzzle == null)
+            {
+                return null;
+            }
+            return Ok(puzzle);
+        }
+
         [HttpGet("category")]
         public IActionResult GetCategories()
         {

--- a/PuzzlePost/Controllers/PuzzleController.cs
+++ b/PuzzlePost/Controllers/PuzzleController.cs
@@ -114,7 +114,10 @@ namespace PuzzlePost.Controllers
         [HttpPut("deactivate/{id}")]
         public ActionResult Deactivate(int id)
         {
+            
             _puzzleRepository.DeactivatePuzzle(id);
+            
+  
             return NoContent();
         }
 

--- a/PuzzlePost/Controllers/RequestController.cs
+++ b/PuzzlePost/Controllers/RequestController.cs
@@ -27,6 +27,13 @@ namespace PuzzlePost.Controllers
             _historyRepository = historyRepository;
         }
 
+        [HttpGet("{id}")]
+        public IActionResult GetRequestById(int id)
+        {
+
+            return Ok(_requestRepository.GetRequestByPuzzleId(id));
+        }
+
         [HttpGet("incoming/{id}")]
         public IActionResult GetIncomingRequests(int id)
         {
@@ -46,11 +53,12 @@ namespace PuzzlePost.Controllers
         {
             UserProfile userProfile = GetCurrentUserProfile();
             var userId = userProfile.Id;
+
+            //if (userId != request.RequestingPuzzleUserId)
+            //{
+            //    return Unauthorized();
+            //}
             request.RequestingPuzzleUserId = userId;
-            if (userId != request.RequestingPuzzleUserId)
-            {
-                return Unauthorized();
-            }
             request.CreateDateTime = DateTime.Now;
             //adding new request for the puzzle
             _requestRepository.Add(request);

--- a/PuzzlePost/Controllers/RequestController.cs
+++ b/PuzzlePost/Controllers/RequestController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -40,12 +41,33 @@ namespace PuzzlePost.Controllers
             return Ok(_requestRepository.GetOutgoingRequestsForUser(id));
         }
 
-        [HttpPost]
-        public IActionResult Post(Request request)
+        [HttpPost("requestwithdeactivation")]
+        public IActionResult PostRequestDeactivatePuzzle(Request request)
         {
-
+            UserProfile userProfile = GetCurrentUserProfile();
+            var userId = userProfile.Id;
+            request.RequestingPuzzleUserId = userId;
+            if (userId != request.RequestingPuzzleUserId)
+            {
+                return Unauthorized();
+            }
+            request.CreateDateTime = DateTime.Now;
+            //adding new request for the puzzle
             _requestRepository.Add(request);
-            return CreatedAtAction("Get", new { id = request.Id }, request);
+            //new instance of puzzle
+            Puzzle puzzle = new Puzzle();
+            //need to specify id of puzzle to know which one to deactivate and take away from shared puzzle list
+            puzzle.Id = request.PuzzleId;
+            //deactivate puzzle and remove from shared puzzle list
+            _puzzleRepository.DeactivatePuzzle(puzzle.Id);
+            return Ok();
+        }
+
+        //Firebase
+        private UserProfile GetCurrentUserProfile()
+        {
+            var firebaseUserId = User.FindFirst(ClaimTypes.NameIdentifier).Value;
+            return _userProfileRepository.GetByFirebaseUserId(firebaseUserId);
         }
     }
 }

--- a/PuzzlePost/Repositories/HistoryRepository.cs
+++ b/PuzzlePost/Repositories/HistoryRepository.cs
@@ -33,5 +33,70 @@ namespace PuzzlePost.Repositories
                 }
             }
         }
+
+        //get history by puzzleId and userprofileId
+        public History GetHistoryByIds(int id, int puzzId)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                      SELECT PuzzleId, UserProfileId, StartDateOwnership, EndDateOwnership
+                      FROM History
+                      WHERE PuzzleId = @puzzleId AND UserProfileId = @id AND EndDateOwnership IS NULL
+                       ";
+
+                    cmd.Parameters.AddWithValue("@id", id);
+                    cmd.Parameters.AddWithValue("@puzzleId", puzzId);
+
+
+                    var reader = cmd.ExecuteReader();
+
+                    if (reader.Read())
+                    {
+                        History history = new History
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("PuzzleId")),
+                            UserProfileId = reader.GetInt32(reader.GetOrdinal("UserProfileId")),
+                            StartDateOwnership = reader.GetDateTime(reader.GetOrdinal("StartDateOwnership")),
+                            EndDateOwnership = DbUtils.GetNullableDateTime(reader, "EndDateOwnership")   
+                        };
+
+                        reader.Close();
+                        return history;
+                    }
+                    else
+                    {
+                        reader.Close();
+                        return null;
+                    }
+
+                }
+            }
+        }
+
+        public void UpdateHistory(History history)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                            UPDATE History
+                            SET  
+                               EndDateOwnership = @endDateOwnership
+                            WHERE Id = @id";
+
+                    cmd.Parameters.AddWithValue("@endDateOwnership", history.EndDateOwnership);
+                    cmd.Parameters.AddWithValue("@id", history.Id);
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
     }
 }

--- a/PuzzlePost/Repositories/HistoryRepository.cs
+++ b/PuzzlePost/Repositories/HistoryRepository.cs
@@ -43,7 +43,7 @@ namespace PuzzlePost.Repositories
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
-                      SELECT PuzzleId, UserProfileId, StartDateOwnership, EndDateOwnership
+                      SELECT Id, PuzzleId, UserProfileId, StartDateOwnership, EndDateOwnership
                       FROM History
                       WHERE PuzzleId = @puzzleId AND UserProfileId = @id AND EndDateOwnership IS NULL
                        ";
@@ -58,7 +58,8 @@ namespace PuzzlePost.Repositories
                     {
                         History history = new History
                         {
-                            Id = reader.GetInt32(reader.GetOrdinal("PuzzleId")),
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            PuzzleId = reader.GetInt32(reader.GetOrdinal("PuzzleId")),
                             UserProfileId = reader.GetInt32(reader.GetOrdinal("UserProfileId")),
                             StartDateOwnership = reader.GetDateTime(reader.GetOrdinal("StartDateOwnership")),
                             EndDateOwnership = DbUtils.GetNullableDateTime(reader, "EndDateOwnership")   

--- a/PuzzlePost/Repositories/IHistoryRepository.cs
+++ b/PuzzlePost/Repositories/IHistoryRepository.cs
@@ -5,6 +5,9 @@ namespace PuzzlePost.Repositories
     public interface IHistoryRepository
     {
         void Add(History history);
-        
+        History GetHistoryByIds(int id, int puzzId);
+        void UpdateHistory(History history);
+
+
     }
 }

--- a/PuzzlePost/Repositories/IPuzzleRepository.cs
+++ b/PuzzlePost/Repositories/IPuzzleRepository.cs
@@ -14,6 +14,7 @@ namespace PuzzlePost.Repositories
         Puzzle GetPuzzleById(int id);
         Puzzle GetPuzzleWithUserProfileById(int id);
         void UpdatePuzzle(Puzzle puzzle);
+        void UpdatePuzzleOwner(Puzzle puzzle);
         Puzzle GetPuzzleWithoutHistoryById(int id);
         void ReactivatePuzzle(int id);
         void DeactivatePuzzle(int id);

--- a/PuzzlePost/Repositories/IPuzzleRepository.cs
+++ b/PuzzlePost/Repositories/IPuzzleRepository.cs
@@ -12,6 +12,7 @@ namespace PuzzlePost.Repositories
         List<Puzzle> GetAllUserPuzzlesById(int id);
         List<Puzzle> GetAllUserPuzzlesInProgressById(int id);
         Puzzle GetPuzzleById(int id);
+        Puzzle GetPuzzleWithUserProfileById(int id);
         void UpdatePuzzle(Puzzle puzzle);
         Puzzle GetPuzzleWithoutHistoryById(int id);
         void ReactivatePuzzle(int id);

--- a/PuzzlePost/Repositories/IRequestRepository.cs
+++ b/PuzzlePost/Repositories/IRequestRepository.cs
@@ -8,5 +8,7 @@ namespace PuzzlePost.Repositories
         List<Request> GetPendingRequestsForUser(int id);
         List<Request> GetOutgoingRequestsForUser(int id);
         void Add(Request request);
+        void UpdateRequestStatus(Request request);
+        Request GetRequestByPuzzleId(int id);
     }
 }

--- a/PuzzlePost/Repositories/PuzzleRepository.cs
+++ b/PuzzlePost/Repositories/PuzzleRepository.cs
@@ -599,10 +599,12 @@ namespace PuzzlePost.Repositories
                     cmd.CommandText = @"
                             UPDATE Puzzle
                             SET  
-                                CurrentOwnerId = @currentOwnerId  
+                                CurrentOwnerId = @currentOwnerId,
+                                CreateDateTime = @createDateTime
                             WHERE Id = @id";
 
                     cmd.Parameters.AddWithValue("@currentOwnerId", puzzle.CurrentOwnerId);
+                    cmd.Parameters.AddWithValue("@createDateTime", puzzle.CreateDateTime);
                     cmd.Parameters.AddWithValue("@id", puzzle.Id);
 
                     cmd.ExecuteNonQuery();

--- a/PuzzlePost/Repositories/PuzzleRepository.cs
+++ b/PuzzlePost/Repositories/PuzzleRepository.cs
@@ -509,7 +509,7 @@ namespace PuzzlePost.Repositories
         }
 
 
-        //owner of puzzle updating
+        //owner of the puzzle able to edit
         public void UpdatePuzzle(Puzzle puzzle)
         {
             using (var conn = Connection)
@@ -586,6 +586,30 @@ namespace PuzzlePost.Repositories
                 }
             }
         }
+
+        //updating current owner id to who the puzzle is getting passed to
+        public void UpdatePuzzleOwner(Puzzle puzzle)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                            UPDATE Puzzle
+                            SET  
+                                CurrentOwnerId = @currentOwnerId  
+                            WHERE Id = @id";
+
+                    cmd.Parameters.AddWithValue("@currentOwnerId", puzzle.CurrentOwnerId);
+                    cmd.Parameters.AddWithValue("@id", puzzle.Id);
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
     }
  }
 

--- a/PuzzlePost/Repositories/PuzzleRepository.cs
+++ b/PuzzlePost/Repositories/PuzzleRepository.cs
@@ -407,11 +407,6 @@ namespace PuzzlePost.Repositories
                                     Id = reader.GetInt32(reader.GetOrdinal("CategoryId")),
                                     Name = reader.GetString(reader.GetOrdinal("Name"))
                                 },
-                                UserProfile = new UserProfile
-                                {
-                                    Id = reader.GetInt32(reader.GetOrdinal("CurrentOwnerId")),
-                                    DisplayName = reader.GetString(reader.GetOrdinal("DisplayName"))
-                                },
                                 Histories = new List<History>()
                             };
                         }
@@ -440,6 +435,76 @@ namespace PuzzlePost.Repositories
                     return puzzle;
                 }
                   
+            }
+        }
+
+        public Puzzle GetPuzzleWithUserProfileById(int id)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                      SELECT p.Id AS PuzzleId, p.CategoryId, p.CurrentOwnerId AS CurrentOwnerId, p.ImageLocation, p.Pieces, p.CreateDateTime,
+                      p.Title, p.Manufacturer, p.Notes, p.IsAvailable,
+
+                      c.Id AS CategoryId, c.Name,
+
+                      up.Id as UserId, up.DisplayName, up.ImageLocation
+
+                      FROM Puzzle p
+                      LEFT JOIN Category c 
+                      ON p.CategoryId = c.Id
+                      LEFT JOIN UserProfile up
+                      ON p.CurrentOwnerId = up.Id
+                      WHERE p.Id = @id
+                      ORDER BY CreateDateTime DESC
+                       ";
+
+                    cmd.Parameters.AddWithValue("@id", id);
+
+                    var reader = cmd.ExecuteReader();
+                    Puzzle puzzle = null;
+
+                    if (reader.Read())
+                    {
+                        puzzle = new Puzzle
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("PuzzleId")),
+                            CategoryId = reader.GetInt32(reader.GetOrdinal("CategoryId")),
+                            CurrentOwnerId = reader.GetInt32(reader.GetOrdinal("CurrentOwnerId")),
+                            ImageLocation = DbUtils.GetNullableString(reader, "ImageLocation"),
+                            Pieces = reader.GetInt32(reader.GetOrdinal("Pieces")),
+                            CreateDateTime = reader.GetDateTime(reader.GetOrdinal("CreateDateTime")),
+                            Title = reader.GetString(reader.GetOrdinal("Title")),
+                            Manufacturer = reader.GetString(reader.GetOrdinal("Manufacturer")),
+                            Notes = DbUtils.GetNullableString(reader, "Notes"),
+                            IsAvailable = reader.GetInt32(reader.GetOrdinal("IsAvailable")),
+                            Category = new Category
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("CategoryId")),
+                                Name = reader.GetString(reader.GetOrdinal("Name"))
+                            },
+                            UserProfile = new UserProfile
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("CurrentOwnerId")),
+                                DisplayName = reader.GetString(reader.GetOrdinal("DisplayName"))
+                            }
+
+                        };
+                        reader.Close();
+                        return puzzle;
+
+                    }
+                    else
+                    {
+                        reader.Close();
+                        return null;
+                    }
+                    
+                }
+
             }
         }
 

--- a/PuzzlePost/Repositories/RequestRepository.cs
+++ b/PuzzlePost/Repositories/RequestRepository.cs
@@ -173,8 +173,8 @@ namespace PuzzlePost.Repositories
                     cmd.Parameters.AddWithValue("@RequestingPuzzleUserId", request.RequestingPuzzleUserId);
                     cmd.Parameters.AddWithValue("@SenderOfPuzzleUserId", request.SenderOfPuzzleUserId);
                     cmd.Parameters.AddWithValue("@Content", request.Content);
-                    cmd.Parameters.AddWithValue("@CreateDateTime", DateTime.Now);
-                    cmd.Parameters.AddWithValue("@StatusId", request.StatusId);
+                    cmd.Parameters.AddWithValue("@CreateDateTime", request.CreateDateTime);
+                    cmd.Parameters.AddWithValue("@StatusId", 1);
 
                     request.Id = (int)cmd.ExecuteScalar();
                 }

--- a/PuzzlePost/client/src/components/Puzzle/PuzzleDetails.js
+++ b/PuzzlePost/client/src/components/Puzzle/PuzzleDetails.js
@@ -8,13 +8,14 @@ import { UserProfileContext } from "../../providers/UserProfileProvider";
 
 
 const PuzzleDetails = () => {
-    const { puzzle, getPuzzleById } = useContext(PuzzleContext);
+    const { puzzle, getPuzzleById, getPuzzleWithUserProfile, puzzleWithProfile } = useContext(PuzzleContext);
     const { activeUser } = useContext(UserProfileContext);
     const { id } = useParams();
     const history = useHistory();
 
     useEffect(() => {
-        getPuzzleById(id)
+        getPuzzleById(id);
+        getPuzzleWithUserProfile(id);
     }, [])
 
     return (
@@ -23,7 +24,7 @@ const PuzzleDetails = () => {
                 <Card className="m-4">
                     <Row margin="m-4">
                         <Col sm="4">
-                            <p className="text-left px-2">Posted by: {puzzle.userProfile.displayName}
+                            <p className="text-left px-2">Posted by: {puzzleWithProfile.userProfile.displayName}
                                 <br></br>
                         on {currentDateTime(puzzle.createDateTime)}</p>
                         </Col>

--- a/PuzzlePost/client/src/components/Request/OutgoingRequestList.js
+++ b/PuzzlePost/client/src/components/Request/OutgoingRequestList.js
@@ -17,7 +17,7 @@ const OutgoingRequestList = () => {
     return (
         <div className="container">
             <div className="row justify-content-center">
-                <h5>Pending Puzzle Requests</h5>
+                <h5>Outgoing Puzzle Requests</h5>
                 <div className="cards-column">
                     {outgoingRequests.map((request) => {
                         return <Request key={request.id} request={request} />

--- a/PuzzlePost/client/src/components/Request/Request.js
+++ b/PuzzlePost/client/src/components/Request/Request.js
@@ -1,11 +1,29 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Card, CardImg, CardBody, Row, Button, Col } from "reactstrap";
 import { currentDateTime } from "../helperFunctions";
 import { NavLink } from "react-router-dom";
 import { UserProfileContext } from "../../providers/UserProfileProvider";
+import { PuzzleContext } from "../../providers/PuzzleProvider";
 
 const Request = ({ request }) => {
     const { activeUser } = useContext(UserProfileContext);
+    const { updatePuzzleOwner } = useContext(PuzzleContext);
+    //setting updating puzzle object into state; need to give value to currentOwnerId to pass into update owner function (will be the requester of the puzzle who will be new owner)
+    const [confirmPuzzle, setConfirmPuzzle] = useState({
+        id: request.puzzleId,
+        categoryId: request.puzzle.categoryId,
+        currentOwnerId: request.requestingPuzzleUserId,
+        title: request.puzzle.title,
+        manufacturer: request.puzzle.manufacturer,
+        imageLocation: request.puzzle.imageLocation,
+        pieces: request.puzzle.pieces,
+        notes: request.puzzle.notes
+    })
+    console.log(confirmPuzzle);
+
+    const updateOwner = () => {
+        updatePuzzleOwner(confirmPuzzle);
+    }
 
     return (
         <>
@@ -27,13 +45,13 @@ const Request = ({ request }) => {
                         </div>
                     </Col>
                 </Row>
-                {/* <CardImg src={request.imageLocation} alt={request.title} /> */}
+                {/* <CardImg src={request.puzzle.imageLocation} alt={request.title} /> */}
                 <CardBody>
                     <Row>
                         <Col sm="4">
                             {window.location.href == "http://localhost:3000/request/incoming" ?
                                 <>
-                                    <Button>Confirm</Button>
+                                    <Button type="button" onClick={updateOwner}>Confirm</Button>
 
                                     <Button>Deny</Button>
                                 </> :

--- a/PuzzlePost/client/src/components/Request/Request.js
+++ b/PuzzlePost/client/src/components/Request/Request.js
@@ -4,15 +4,16 @@ import { currentDateTime } from "../helperFunctions";
 import { NavLink } from "react-router-dom";
 import { UserProfileContext } from "../../providers/UserProfileProvider";
 import { PuzzleContext } from "../../providers/PuzzleProvider";
+import { RequestContext } from "../../providers/RequestProvider";
 
 const Request = ({ request }) => {
     const { activeUser } = useContext(UserProfileContext);
     const { updatePuzzleOwner } = useContext(PuzzleContext);
+    const { getAllPendingRequests } = useContext(RequestContext);
     //setting updating puzzle object into state; need to give value to currentOwnerId to pass into update owner function (will be the requester of the puzzle who will be new owner)
     const [confirmPuzzle, setConfirmPuzzle] = useState({
         id: request.puzzleId,
         categoryId: request.puzzle.categoryId,
-        currentOwnerId: request.requestingPuzzleUserId,
         title: request.puzzle.title,
         manufacturer: request.puzzle.manufacturer,
         imageLocation: request.puzzle.imageLocation,
@@ -23,6 +24,8 @@ const Request = ({ request }) => {
 
     const updateOwner = () => {
         updatePuzzleOwner(confirmPuzzle);
+        getAllPendingRequests(parseInt(activeUser.id));
+
     }
 
     return (

--- a/PuzzlePost/client/src/components/Request/Request.js
+++ b/PuzzlePost/client/src/components/Request/Request.js
@@ -31,9 +31,13 @@ const Request = ({ request }) => {
                 <CardBody>
                     <Row>
                         <Col sm="4">
-                            <Button>Confirm</Button>
+                            {window.location.href == "http://localhost:3000/request/incoming" ?
+                                <>
+                                    <Button>Confirm</Button>
 
-                            <Button>Deny</Button>
+                                    <Button>Deny</Button>
+                                </> :
+                                null}
                         </Col>
                     </Row>
                 </CardBody>

--- a/PuzzlePost/client/src/components/Request/Request.js
+++ b/PuzzlePost/client/src/components/Request/Request.js
@@ -52,7 +52,7 @@ const Request = ({ request }) => {
                 <CardBody>
                     <Row>
                         <Col sm="4">
-                            {window.location.href == "http://localhost:3000/request/incoming" ?
+                            {(window.location.href == "http://localhost:3000/request/incoming" || window.location.href == "http://localhost:3001/request/incoming") ?
                                 <>
                                     <Button type="button" onClick={updateOwner}>Confirm</Button>
 

--- a/PuzzlePost/client/src/providers/PuzzleProvider.js
+++ b/PuzzlePost/client/src/providers/PuzzleProvider.js
@@ -123,6 +123,18 @@ export function PuzzleProvider(props) {
         )
     };
 
+    const updatePuzzleOwner = (puzzle) => {
+        getToken().then((token) => fetch(`/api/puzzle/updatepuzzleowner/${puzzle.id}`, {
+            method: "PUT",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(puzzle)
+        })
+        )
+    };
+
     const reactivatePuzzle = (id) => {
         getToken().then((token) => fetch(`/api/puzzle/reactivate/${id}`, {
             method: "PUT",
@@ -149,7 +161,7 @@ export function PuzzleProvider(props) {
 
     return (
 
-        <PuzzleContext.Provider value={{ getPuzzleWithUserProfile, puzzleWithProfile, deactivatePuzzle, reactivatePuzzle, aPuzzle, editPuzzle, puzzle, userPuzzles, inactiveUserPuzzles, getPuzzleWithoutHistoryById, getPuzzleById, getAllInactivePuzzlesByUser, getAllPuzzlesByUser, getAllActivePuzzles, activePuzzles, addPuzzle, categoriesForPuzzle, categories }}>
+        <PuzzleContext.Provider value={{ updatePuzzleOwner, getPuzzleWithUserProfile, puzzleWithProfile, deactivatePuzzle, reactivatePuzzle, aPuzzle, editPuzzle, puzzle, userPuzzles, inactiveUserPuzzles, getPuzzleWithoutHistoryById, getPuzzleById, getAllInactivePuzzlesByUser, getAllPuzzlesByUser, getAllActivePuzzles, activePuzzles, addPuzzle, categoriesForPuzzle, categories }}>
             {props.children}
         </PuzzleContext.Provider>
     );

--- a/PuzzlePost/client/src/providers/PuzzleProvider.js
+++ b/PuzzlePost/client/src/providers/PuzzleProvider.js
@@ -11,6 +11,7 @@ export function PuzzleProvider(props) {
     const [inactiveUserPuzzles, setInactiveUserPuzzles] = useState([]);
     const [puzzle, setPuzzle] = useState({ userProfile: {}, category: {}, histories: [] });
     const [aPuzzle, setAPuzzle] = useState({ category: {} });
+    const [puzzleWithProfile, setPuzzleWithProfile] = useState({ userProfile: {} });
 
     const getAllActivePuzzles = () => {
         return getToken().then((token) => {
@@ -98,6 +99,18 @@ export function PuzzleProvider(props) {
 
     };
 
+    const getPuzzleWithUserProfile = (id) => {
+        getToken().then((token) => fetch(`/api/puzzle/getwithuserprofile/${id}`, {
+            method: "GET",
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
+        })
+            .then((res) => res.json()).then(setPuzzleWithProfile)
+        )
+
+    };
+
     const editPuzzle = (puzzle) => {
         getToken().then((token) => fetch(`/api/puzzle/${puzzle.id}`, {
             method: "PUT",
@@ -136,7 +149,7 @@ export function PuzzleProvider(props) {
 
     return (
 
-        <PuzzleContext.Provider value={{ deactivatePuzzle, reactivatePuzzle, aPuzzle, editPuzzle, puzzle, userPuzzles, inactiveUserPuzzles, getPuzzleWithoutHistoryById, getPuzzleById, getAllInactivePuzzlesByUser, getAllPuzzlesByUser, getAllActivePuzzles, activePuzzles, addPuzzle, categoriesForPuzzle, categories }}>
+        <PuzzleContext.Provider value={{ getPuzzleWithUserProfile, puzzleWithProfile, deactivatePuzzle, reactivatePuzzle, aPuzzle, editPuzzle, puzzle, userPuzzles, inactiveUserPuzzles, getPuzzleWithoutHistoryById, getPuzzleById, getAllInactivePuzzlesByUser, getAllPuzzlesByUser, getAllActivePuzzles, activePuzzles, addPuzzle, categoriesForPuzzle, categories }}>
             {props.children}
         </PuzzleContext.Provider>
     );

--- a/PuzzlePost/client/src/providers/RequestProvider.js
+++ b/PuzzlePost/client/src/providers/RequestProvider.js
@@ -30,23 +30,23 @@ export function RequestProvider(props) {
         })
     };
 
-    const addRequest = (request) => {
+    const addRequestDeactivatePuzzle = (request) => {
 
-        getToken().then((token) => fetch("/api/request", {
+        getToken().then((token) => fetch("/api/request/requestwithdeactivation", {
             method: "POST",
             headers: {
                 Authorization: `Bearer ${token}`,
                 "Content-Type": "application/json",
             },
             body: JSON.stringify(request)
-        }).catch((err) => console.log(err))
+        })
 
         )
     };
 
     return (
 
-        <RequestContext.Provider value={{ addRequest, getAllPendingRequests, pendingRequests, getAllOutgoingRequests, outgoingRequests }}>
+        <RequestContext.Provider value={{ addRequestDeactivatePuzzle, getAllPendingRequests, pendingRequests, getAllOutgoingRequests, outgoingRequests }}>
             {props.children}
         </RequestContext.Provider>
     );


### PR DESCRIPTION
1. reactivation changes Puzzle table from IsAvailable 1 to IsAvailable 0
2. posting new puzzle will also post new history for that current owner and keep track of it as it passes from one person to another
3. when request button clicked will allow current user to write message and send the request to current owner
4. current owner of puzzle should see in their incoming request page the new pending request
5. when current owner of puzzle clicks confirm, will
   -PUT puzzle table with current owner Id being the person requesting puzzle and date changes to current time
  -PUT history table with end date ownership being current time
  -POST history table with new current owner and start date as current time
  -PUT Request table with statusId changed to 2 for approved and removed from current user's incoming request page
6. details page showing
